### PR TITLE
refactor: replace SearchSection type with enum for better type safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ console.log(data);
 ```
 
 ```typescript
-// Deprecated: v1.2.4
+// Deprecated: v2.0.0
 // type SearchSection = 'all' | 'artist' | 'song' | 'album';
 
 export enum SearchSection {

--- a/README.md
+++ b/README.md
@@ -61,7 +61,16 @@ console.log(data);
 ```
 
 ```typescript
-type SearchSection = 'all' | 'artist' | 'song' | 'album';
+// Deprecated: v1.2.4
+// type SearchSection = 'all' | 'artist' | 'song' | 'album';
+
+export enum SearchSection {
+  ALL = 'all',
+  ARTIST = 'artist',
+  SONG = 'song',
+  ALBUM = 'album',
+}
+
 interface ISearchParams {
   query: string;
   section?: SearchSection;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "melona",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "melona",
-      "version": "1.2.3",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melona",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "description": "멜론 음원 서비스의 여러 데이터를 JSON으로 변환하는 크롤러",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/search.test.ts
+++ b/src/search.test.ts
@@ -1,4 +1,4 @@
-import { MelonSearch } from './search';
+import { MelonSearch, SearchSection } from './search';
 import { randomBytes } from 'crypto';
 
 describe('MelonSearch', () => {
@@ -9,6 +9,15 @@ describe('MelonSearch', () => {
       query,
     });
     expect(search).toHaveLength(0);
+  });
+  test('searchSong: array length should not be 0 when result', async () => {
+    const melonSearch = new MelonSearch();
+    const query = '아이유';
+    const search = await melonSearch.searchSong({
+      section: SearchSection.ARTIST,
+      query,
+    });
+    expect(search).not.toHaveLength(0);
   });
   test('parseTable: array length should be 0 when no result', async () => {
     const melonSearch = new MelonSearch();

--- a/src/search.ts
+++ b/src/search.ts
@@ -3,7 +3,12 @@ import type { ISongData } from '.';
 import * as cheerio from 'cheerio';
 import { Config } from './config';
 
-export type SearchSection = 'all' | 'artist' | 'song' | 'album';
+export enum SearchSection {
+  ALL = 'all',
+  ARTIST = 'artist',
+  SONG = 'song',
+  ALBUM = 'album',
+}
 
 export interface ISearchParams {
   query: string;


### PR DESCRIPTION
Add `SearchSection` enum:
```typescript
export enum SearchSection {
  ALL = 'all',
  ARTIST = 'artist',
  SONG = 'song',
  ALBUM = 'album',
}
```